### PR TITLE
add missing newline before modules list

### DIFF
--- a/en-US/middlewares/README.md
+++ b/en-US/middlewares/README.md
@@ -7,6 +7,7 @@ name: Middlewares
 Middlewares and helper modules allow you easily plugin/unplugin features for your Macaron applications.
 
 There are already many [middlewares and modules](https://github.com/go-macaron) to simplify your work:
+
 - [auth](https://github.com/go-macaron/auth) - HTTP Basic authentication
 - [bindata](/docs/middlewares/bindata) - Embed binary data as static and template files
 - [binding](/docs/middlewares/binding) - Request data binding and validation


### PR DESCRIPTION
I inadvertently removed the newline with the PR #10, the markdown lib used by the documentation website doesn't format see the content as a list.

![screen shot 2017-02-27 at 23 55 45](https://cloud.githubusercontent.com/assets/2451004/23383877/b64ac326-fd48-11e6-947c-8a6cad70be6a.png)
